### PR TITLE
Fixed broken link to tile sets PDF

### DIFF
--- a/Getting_Started_with_Palladio.md
+++ b/Getting_Started_with_Palladio.md
@@ -386,7 +386,7 @@ Palladio has some other cool capabilities we haven't discussed here. The
 image above shows one that I like: the ability to use other
 georeferenced maps (in this case an old railroad map from the New York
 Public Library) as basemaps. Here's a tutorial on how to do that:
-http://hdlab.stanford.edu/doc/Tutorial%20for%20creating%20URL%20based%20tilesets\_low.pdf.
+<http://hdlab.stanford.edu/doc/Tutorial%20for%20creating%20URL%20based%20tilesets_low.pdf>.
 
 Other cool things you can do with Palladio:
 


### PR DESCRIPTION
The backslash in the url and the period after PDF were breaking the link to the tile sets instruction link. I fixed those so the link should work.